### PR TITLE
Add golang-migrate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ This project is a collection of code samples, experiments, and tutorials as I ex
 - [Go Official Website](https://golang.org/)
 - [Go by Example](https://gobyexample.com/)
 - [A Tour of Go](https://tour.golang.org/)
+
+## Database Migrations
+
+This project uses [golang-migrate](https://github.com/golang-migrate/migrate) to manage database schema changes. Install the CLI with:
+
+```bash
+go install github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+```
+
+Migration scripts live in the `migrations` directory. The initial migration sets up the `books` and `users` tables with seed data.
+

--- a/migrations/0001_initial.down.sql
+++ b/migrations/0001_initial.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS books;
+

--- a/migrations/0001_initial.up.sql
+++ b/migrations/0001_initial.up.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS books (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    author VARCHAR(255) NOT NULL,
+    quantity INT NOT NULL
+);
+
+INSERT INTO books (title, author, quantity) VALUES
+('The Go Programming Language', 'Alan A. A. Donovan', 3),
+('Go in Action', 'William Kennedy', 2),
+('Go Web Programming', 'Sau Sheong Chang', 4),
+('Go Programming Blueprints', 'Mat Ryer', 6),
+('Learning Go', 'Jon Bodner', 1),
+('Go Design Patterns', 'Mario Castro Contreras', 2),
+('Go Systems Programming', ' Mihalis Tsoukalos', 3),
+('Concurrency in Go', 'Katherine Cox-Buday', 4),
+('Go in Practice', 'Matt Butcher', 2),
+('Go Cookbook', 'Aaron Torres', 5),
+('Mastering Go', 'Mihalis Tsoukalos', 3),
+('Go Programming by Example', 'Agus Kurniawan', 4),
+('Go for DevOps', 'Josh Armitage', 2),
+('Go in Action, Second Edition', 'William Kennedy', 1),
+('Introducing Go', 'Caleb Doxsey', 5);
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL
+);


### PR DESCRIPTION
## Summary
- split existing `init.sql` into migrations
- document how to install `golang-migrate` CLI

## Testing
- `go install github.com/golang-migrate/migrate/v4/cmd/migrate@latest` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f59c0d23c832298feb525a339d101