### PR TITLE
Use env vars for frontend proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_DSN=root:secret@tcp(mysql:3306)/bookstore
+API_HOST=api
+API_PORT=8080
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -47,4 +47,12 @@ Start all services with:
 docker compose up
 ```
 
-Visit [http://localhost:3000](http://localhost:3000) to access the UI.
+Create a `.env` file to adjust the proxy settings used by the frontend server:
+
+```
+API_HOST=api
+API_PORT=8080
+PORT=3000
+```
+
+Visit `http://localhost:3000` (or whichever `PORT` you choose) to access the UI.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,4 +68,8 @@ services:
       - ./frontend:/app
     ports:
       - "3000:3000"
+    environment:
+      API_HOST: api
+      API_PORT: 8080
+      PORT: 3000
     command: node server.js

--- a/frontend/app.jsx
+++ b/frontend/app.jsx
@@ -1,4 +1,4 @@
-const API_BASE = 'http://localhost:8989';
+const API_BASE = '/api';
 
 function App() {
   const [token, setToken] = React.useState(sessionStorage.getItem('token'));

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -2,9 +2,24 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 
-const PORT = 3000;
-const API_HOST = 'http://localhost';
-const API_PORT = 8989;
+// Load environment variables from a local .env if present
+[path.join(__dirname, '.env'), path.join(__dirname, '..', '.env')].forEach((p) => {
+  if (fs.existsSync(p)) {
+    fs.readFileSync(p, 'utf-8')
+      .split(/\n/)
+      .forEach((line) => {
+        const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)\s*$/);
+        if (match) {
+          const [, key, value] = match;
+          if (!process.env[key]) process.env[key] = value;
+        }
+      });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+const API_HOST = process.env.API_HOST || 'api';
+const API_PORT = process.env.API_PORT || 8080;
 
 const MIME_TYPES = {
   '.html': 'text/html',
@@ -58,5 +73,5 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(PORT, () => {
-  console.log(`Frontend running on http://localhost:${PORT}`);
+  console.log(`Frontend running on port ${PORT}`);
 });

--- a/main.go
+++ b/main.go
@@ -35,8 +35,7 @@ func initDB() {
 }
 
 func main() {
-	if err := godotenv.Load(); 
-	err != nil {
+	if err := godotenv.Load(); err != nil {
 		log.Println("⚠️ No .env file found")
 	}
 


### PR DESCRIPTION
## Summary
- load optional env file for the frontend server
- remove localhost from React and proxy
- document environment variables for the frontend
- add example `.env`
- configure docker-compose frontend service with variables

## Testing
- `node -c frontend/server.js`
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f9ab6a99c8322ae799c74e658df7c